### PR TITLE
transcribe: Free ctx before return

### DIFF
--- a/src/Whisper.jl
+++ b/src/Whisper.jl
@@ -41,6 +41,9 @@ function transcribe(model, data)
         t1 = whisper_full_get_segment_t1(ctx, i)
         @debug "Time for inference: ", t0-t1
     end
+
+    whisper_free(ctx)
+
     return result
 end
 


### PR DESCRIPTION
Otherwise using `transcribe` in a loop quickly causes an OOM situation.